### PR TITLE
自己紹介欄の追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,7 +53,8 @@ before_action :admin_user,     only: :destroy
   private
     def user_params
       params.require(:user).permit(:name, :email, :password,
-                                   :password_confirmation)
+                                   :password_confirmation,
+                                   :self_introduction)
     end
 
 # 正しいユーザーかどうか確認

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
                     uniqueness: { case_sensitive: false }
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 },allow_nil: true
+  validates :self_introduction, presence: false, length: { maximum: 140 }
 
 # 渡された文字列のハッシュ値を返す
   def User.digest(string)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -18,7 +18,7 @@
       <%= f.password_field :password_confirmation, class: 'form-control' %>
 
 <%= f.label :self_introduction, "自己紹介文を書きましょう" %>
-      <%= f.text_area :self_introduction, class: 'form-control', id: 'user_introduction', value: "国籍, 日本語のレベル, 趣味, 特技など..."%>
+      <%= f.text_area :self_introduction, class: 'form-control', id: 'user_introduction', placeholder: "国籍, 日本語のレベル, 趣味, 特技など..."%>
 
 <%= f.submit "保存する！", class: "btn btn-primary" %>
     <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -16,6 +16,10 @@
       <%= f.password_field :password, class: 'form-control' %>
 <%= f.label :password_confirmation, "パスワードをもう一度入れてください" %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+<%= f.label :self_introduction, "自己紹介文を書きましょう" %>
+      <%= f.text_area :self_introduction, class: 'form-control', id: 'user_introduction', value: "国籍, 日本語のレベル, 趣味, 特技など..."%>
+
 <%= f.submit "保存する！", class: "btn btn-primary" %>
     <% end %>
 <div class="gravatar_edit">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,12 @@
         <%= gravatar_for @user %>
         <%= @user.name %>
       </h1>
+
+      <%#自己紹介%>
+      <div class = "self_introduction">
+        <%= @user.self_introduction %>
+      </div>
+
     </section>
   </aside>
   <div class="col-md-8">

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,7 @@
 const { environment } = require('@rails/webpacker')
 
 module.exports = environment
+<<<<<<< HEAD
 
 
 const webpack = require('webpack')
@@ -12,3 +13,5 @@ environment.plugins.append(
     Popper: ['popper.js', 'default']
   })
 )
+=======
+>>>>>>> modified_static_pages

--- a/db/migrate/20200907063949_add_self_introduction_to_users.rb
+++ b/db/migrate/20200907063949_add_self_introduction_to_users.rb
@@ -1,0 +1,5 @@
+class AddSelfIntroductionToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :self_introduction, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_123354) do
+ActiveRecord::Schema.define(version: 2020_09_07_063949) do
 
   create_table "feedback_posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "content"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_123354) do
     t.datetime "activated_at"
     t.string "reset_digest"
     t.datetime "reset_sent_at"
+    t.text "self_introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
user#showのトップ画像直下に自己紹介欄を設けました。
それに伴い
・usersのDBにself_introductionカラムをtext型で作成
・usersコントローラのprivate以下のpermitに:self_introductionを追加
・モデルにはvalidationとして140字制限を付随させています。