### PR TITLE
簡単ログインのバグの修正

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,9 +1,14 @@
 class GuestSessionsController < ApplicationController
 
   def create
-    user = User.create(id:999 ,name: 'りんごちゃん', email: 'easy_login@example.com')
-    log_in_as_guset(user)
-    flash[:success] = 'ゲストユーザーでログインしました'
-    redirect_to user_path(user)
+    if user = User.find(999)
+      log_in(user)
+      redirect_to user_path(user)
+    else
+      user = User.create(id:999 ,name: 'りんごちゃん', email: 'easy_login@example.com')
+      log_in_as_guset(user) #application_controller.rbに記述してる。
+      flash[:success] = 'ゲストユーザーでログインしました'
+      redirect_to user_path(user)
+    end
   end
 end


### PR DESCRIPTION
簡単ログインに2回目以降ログインできないという致命的なバグがあったので修正しました。
guest_session_controller.rb内にif文でDBにidが999のユーザーがあったら、そのユーザーでログインする条件文を付け加えることで回避しました。