### PR TITLE
ページの整形

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,7 @@
 import 'bootstrap';
 import '../stylesheets/application.scss';
 import '../stylesheets/staticpages.scss';
+import '../stylesheets/userpages.scss';
 import './bootstrap_custom.js'
 
 require("@rails/ujs").start()

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -290,3 +290,13 @@ height:50px;
   border-left : solid 1px #dcdcdc; /*gainsboro*/
   color: #2e8b57; /*seagreen*/
 }
+
+.title_letter{
+  padding: 0px 2px 2px 2px;
+  margin: 10px 3px 3px 3px;
+  background-color: #ffffff;
+  display: inline-block;
+  border-bottom : solid 1px #808080; /*darkgray*/
+  border-right : solid 1px #808080; /*darkgray*/
+  opacity: 0.8;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -12,10 +12,10 @@
 
 .upper_info_row{
   background-color:rgba(245,245,245,0.9);
-  border-top : solid 0.8px #dcdcdc; /*gainsboro*/
+  border-top : solid 1px #dcdcdc; /*gainsboro*/
   border-bottom : solid 1px #808080; /*darkgray*/
   border-right : solid 1px #808080; /*darkgray*/
-  border-left : solid 0.8px #dcdcdc; /*gainsboro*/
+  border-left : solid 1px #dcdcdc; /*gainsboro*/
   color: #2e8b57; /*seagreen*/
   height: 300px;
 }
@@ -260,16 +260,33 @@ height:50px;
 }
 /*フッターここまで*/
 
-
-
-/*タブについて*/
-.tab_wrap{width:500px; margin:80px auto;}
+/*タブ部分について*/
 .tab_area{font-size:0; margin:0 10px;}
-.tab_area label{width:150px; margin:0 5px; display:inline-block; padding:12px 0; color:#999; background:#ddd; text-align:center; font-size:13px; cursor:pointer; transition:ease 0.2s opacity;}
-.tab_area label:hover{opacity:0.5;}
-.panel_area{background:#fff;}
-.tab_panel{width:100%; padding:80px 0; display:none;}
-.tab_panel p{font-size:14px; letter-spacing:1px; text-align:center;}
-
-.tab_area label.active{background:#fff; color:#000;}
-.tab_panel.active{display:block;}
+.tab_a{
+  width:150px;
+  margin:0 5px;
+  display:inline-block;
+  padding:12px 0;
+  color:#ffffff;
+  background-color: #2e8b57; /*seagreen*/
+  text-align:center;
+  font-size:13px;
+  cursor:pointer;
+  transition:ease 0.2s opacity;
+  border: solid 1px #808080; /*darkgray*/
+  opacity: 0.9;
+}
+.tab_a:hover{opacity:0.5;}
+.tab_a:active{
+  background-color:rgba(245,245,245,0.9);
+}
+.panel_area{
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-bottom: 15px;
+  background-color:rgba(245,245,245,0.9);
+  border-bottom : solid 1px #808080; /*darkgray*/
+  border-right : solid 1px #808080; /*darkgray*/
+  border-left : solid 1px #dcdcdc; /*gainsboro*/
+  color: #2e8b57; /*seagreen*/
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,5 +1,50 @@
 @import './bootstrap_custom.scss';
 
+/*ページ全体に関するCSS*/
+.upper_info{
+  text-align: center;
+}
+
+.upper_user_info{
+  margin-top: 40px;
+  text-align: center;
+}
+
+.upper_info_row{
+  background-color:rgba(245,245,245,0.9);
+  border-top : solid 0.8px #dcdcdc; /*gainsboro*/
+  border-bottom : solid 1px #808080; /*darkgray*/
+  border-right : solid 1px #808080; /*darkgray*/
+  border-left : solid 0.8px #dcdcdc; /*gainsboro*/
+  color: #2e8b57; /*seagreen*/
+  height: 300px;
+}
+
+.self_introduction{
+  margin: 25px;
+  border: solid 1px #dcdcdc;
+  height: 250px;
+}
+
+.upper_post{
+  margin: 25px 0;
+}
+
+.post_count{
+  margin-right: 5px;
+  margin-left: 5px;
+  margin-top: 5px;
+  margin-bottom: 10px;
+}
+
+.self_introduction_text{
+  position: absolute;
+  top: 50%; /*親要素を起点に上から50%*/
+  left: 50%;  /*親要素を起点に左から50%*/
+  transform: translateY(-50%) translateX(-50%); /*要素の大きさの半分ずつを戻す*/
+  -webkit-transform: translateY(-50%) translateX(-50%);
+}
+
 /*ロードアニメーション*/
 #page-animate::before {
  content: '';
@@ -51,6 +96,21 @@
 }
 
 .general_button:hover{
+  background-color: #f9c500;
+}
+
+/*一般じゃないボタン*/
+.ungeneral_button{
+  text-decoration: none;
+  text-align: center;
+  background-color: #FFA500;
+  border-radius: 5px;
+  -weabkit-transition: all 0.5s;
+  transition: all 0.5s;
+  margin: 10px;
+}
+
+.ungeneral_button:hover{
   background-color: #f9c500;
 }
 
@@ -199,3 +259,17 @@ height:50px;
       transition: background-color 0.1s linear; /* 追加 */
 }
 /*フッターここまで*/
+
+
+
+/*タブについて*/
+.tab_wrap{width:500px; margin:80px auto;}
+.tab_area{font-size:0; margin:0 10px;}
+.tab_area label{width:150px; margin:0 5px; display:inline-block; padding:12px 0; color:#999; background:#ddd; text-align:center; font-size:13px; cursor:pointer; transition:ease 0.2s opacity;}
+.tab_area label:hover{opacity:0.5;}
+.panel_area{background:#fff;}
+.tab_panel{width:100%; padding:80px 0; display:none;}
+.tab_panel p{font-size:14px; letter-spacing:1px; text-align:center;}
+
+.tab_area label.active{background:#fff; color:#000;}
+.tab_panel.active{display:block;}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -17,7 +17,6 @@
   border-right : solid 1px #808080; /*darkgray*/
   border-left : solid 1px #dcdcdc; /*gainsboro*/
   color: #2e8b57; /*seagreen*/
-  height: 300px;
 }
 
 .self_introduction{

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -243,15 +243,20 @@ height:50px;
 .footer-menu{
     font-size: 1rem;
     color: #2e8b57; /*seagreen*/
-    background-color: #ffffff;
+    background-color:rgba(245,245,245,0.9);
     display: inline-block;
     padding: 0 15px;
     cursor: pointer;
     transition: background-color 1s linear;
     transition: color 1s linear;
     list-style: none;
-    margin-bottom: 5px
+    margin: 5px;
+    border-top : solid 1px #dcdcdc; /*gainsboro*/
+    border-bottom : solid 1px #808080; /*darkgray*/
+    border-right : solid 1px #808080; /*darkgray*/
+    border-left : solid 1px #dcdcdc; /*gainsboro*/
   }
+
 .footer-menu:hover {
       background-color: #2e8b57; /*seagreen*/
       color: #ffffff; /*白*/

--- a/app/javascript/stylesheets/staticpages.scss
+++ b/app/javascript/stylesheets/staticpages.scss
@@ -29,4 +29,11 @@
   margin:15px;
 }
 
+
+/*お題を投稿してくださいのところ*/
+.tag_field{
+  display: inline-block;
+  margin: 5px;
+}
+
 /*home終わり*/

--- a/app/javascript/stylesheets/userpages.scss
+++ b/app/javascript/stylesheets/userpages.scss
@@ -1,0 +1,14 @@
+
+/*user#indexについて*/
+
+.users{
+  list-style: none;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-bottom: 15px;
+  background-color:rgba(245,245,245,0.9);
+  border-bottom : solid 1px #808080; /*darkgray*/
+  border-right : solid 1px #808080; /*darkgray*/
+  border-left : solid 1px #dcdcdc; /*gainsboro*/
+}
+/*user#indexここまで*/

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <nav>
+  <nav class = "container">
     <ul class = "footer_ul">
       <li><%= link_to "ホーム", root_path, {class: "footer-menu"} %></li>
       <li><%= link_to "LinGoChanって何?", about_path, {class: "footer-menu"} %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
       </body>
   <%#ここまで%>
 
-      <div class="container">
+      <div class="container main_cantainer">
         <% flash.each do |message_type, message| %>
           <div class="alert alert-<%= message_type %>"><%= message %></div>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,9 +31,10 @@
         <% end %>
 
         <%= yield %>
+      </div>
+
         <%= render("layouts/footer")%>
         <%= debug(params) if Rails.env.development? %>
-    </div>
 
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,9 +15,9 @@
 
   <body>
     <%= render("layouts/header") %>
-
+  <%# バックグラウンドのための記述 %>
     <div class = "main_contents",
-     style="background-image: url(<%= asset_pack_path 'media/images/background_img.png' %>); background-size: cover; background-repeat: repeat-x">
+     style="background-image: url(<%= asset_pack_path 'media/images/background_img.png' %>); background-size: cover; background-repeat: repeat-y">
 
   <%#ロードアニメーションのための記述%>
       <body class="is-slide" id="page-animate">

--- a/app/views/reply_posts/_reply_post.html.erb
+++ b/app/views/reply_posts/_reply_post.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class = "reply_post">
-      <li id="reply_post-<%= reply_post.id %>">
+      <div id="reply_post-<%= reply_post.id %>">
         <%= link_to gravatar_for(reply_post.user, size: 50), reply_post.user %>
         <span class="user"><%= link_to reply_post.user.name, reply_post.user %></span>
 
@@ -30,6 +30,6 @@
         <span class="timestamp">
            <%= time_ago_in_words(reply_post.created_at) %>前
         </span>
-      </li>
+      </div>
     </div>
   </dev>

--- a/app/views/shared/_feedback_feed.html.erb
+++ b/app/views/shared/_feedback_feed.html.erb
@@ -1,10 +1,13 @@
 <% if @feedback_posts.present? %>
-  <ol class="sublect_posts">
 
+  <div class="row sublect_posts">
     <% @feedback_posts.each do |feedback_post| %>
-    <%= render "feedback_posts/feedback_post", feedback_post: feedback_post %>
+      <div class = "col-md-6 post_item">
+        <%= render "feedback_posts/feedback_post", feedback_post: feedback_post %>
+      </div>
     <% end %>
-  </ol>
+  </div>
+
   <%= paginate @feedback_posts %>
 
 <% else %>

--- a/app/views/shared/_reply_feed.html.erb
+++ b/app/views/shared/_reply_feed.html.erb
@@ -1,9 +1,11 @@
 <% if @reply_posts.present? %>
-  <ol class="sublect_posts">
+  <div class="row sublect_posts">
     <% @reply_posts.each do |reply_post| %>
+    <div class = "col-md-6 post_item">
       <%= render "reply_posts/reply_post", reply_post: reply_post %>
+    </div>
     <% end %>
-  </ol>
+  </div>
   <%= paginate @reply_posts %>
 
 <% else %>

--- a/app/views/shared/_subject_feed.html.erb
+++ b/app/views/shared/_subject_feed.html.erb
@@ -1,7 +1,13 @@
 <% if @subject_posts.present? %>
-  <ol class="sublect_posts">
-    <%= render @subject_posts %>
-  </ol>
+
+  <div class="row sublect_posts">
+    <% @subject_posts.each do |subject_post| %>
+      <div class = "col-md-6 post_item">
+        <%= render "subject_posts/subject_post", subject_post: subject_post %>
+      </div>
+    <% end %>
+  </div>
+
   <%= paginate @subject_posts %>
 
 <% else %>

--- a/app/views/shared/_subject_posts_form.html.erb
+++ b/app/views/shared/_subject_posts_form.html.erb
@@ -2,14 +2,15 @@
 <%= form_with model: @subject_post do |f| %>
 
   <%= render 'shared/error_messages', object: f.object %>
-<div class="img_explanation">
+<h1 class="img_explanation">
   <%= f.label :img, "お題を投稿してください！" %>
-</div>
+</h1>
 <div class = "image_field">
   <%= f.file_field :img, class: "image", accept: 'image/jpeg,image/gif,image/png' %>
 </div>
 
 <div class = tag_field_container>
+<br>
     <div class = tag_explanation>
       <p> 半角スペースを入れると複数のタグを登録できます</p>
       <p> (例)空 海 森 </p>
@@ -19,10 +20,8 @@
         <%= f.label :tag_name, "タグ"%>
         <%= f.text_field :tag_name %>
     </div>
-</div>
-
  <%= f.submit "投稿する！", class: "btn btn-primary" %>
-
+</div>
 <% end %>
 
 <script type="text/javascript">

--- a/app/views/shared/_tab_contents.html.erb
+++ b/app/views/shared/_tab_contents.html.erb
@@ -1,0 +1,45 @@
+<%#homeに関して%>
+<div class="tab-content panel_area">
+
+  <div id="subject_posts" class="tab-pane active tab_panel">
+    <%#お題投稿のタブ%>
+      <% if current_page?(root_path) %>
+        <h3 class = "title_letter">投稿したお題一覧</h3>
+        <%= render 'shared/subject_feed' %>
+      <% else %>
+        <% if @user.subject_posts.any? %>
+          <h3 class = "title_letter"><%= @user.name %>のお題 (<%= @user.subject_posts.count %>)</h3>
+          <%= render "shared/subject_feed", subject_posts: @user.subject_posts %>
+        <% end %>
+      <% end %>
+  </div>
+
+  <div id="reply_posts" class="tab-pane tab_panel">
+    <%#一言の投稿のタブの中身%>
+      <% if current_page?(root_path) %>
+        <h3 class = "title_letter">投稿したひとこと一覧</h3>
+        <%= render 'shared/reply_feed' %>
+      <% else %>
+        <% if @user.reply_posts.any? %>
+          <h3 class = "title_letter"><%= @user.name %>のひとこと (<%= @user.reply_posts.count %>)</h3>
+        <% end %>
+        <%= render "shared/reply_feed", reply_posts: @user.reply_posts %>
+      <% end %>
+  </div>
+
+  <div id="feedback_posts" class="tab-pane tab_panel">
+    <%#フィードバックタブの中身%>
+      <% if current_page?(root_path) %>
+        <h3 class = "title_letter">投稿したフィードバック一覧</h3>
+        <%= render 'shared/feedback_feed' %>
+      <% else %>
+        <% if @user.feedback_posts.any? %>
+          <h3 class = "title_letter"><%= @user.name %>のフィードバック (<%= @user.feedback_posts.count %>)</h3>
+        <% end %>
+        <%= render "shared/feedback_feed", feedback_posts: @user.feedback_posts %>
+      <% end %>
+  </div>
+</div>
+
+<div class = "homepage-title under_tub_title">
+</div>

--- a/app/views/shared/_tab_switch.html.erb
+++ b/app/views/shared/_tab_switch.html.erb
@@ -1,14 +1,14 @@
   <!-- 上部のタブの部分 -->
 
 <main class="p-3">
-  <ul class="nav nav-tabs">
-    <li class="nav-item">
-      <a href="#subject_posts" class="nav-link active" data-toggle="tab">お題</a>
+  <ul class="nav nav-tabs tab_area">
+    <li class="nav-item tab1_label">
+      <a href="#subject_posts" class="nav-link active tab_a" data-toggle="tab">お題</a>
     </li>
-    <li class="nav-item">
-      <a href="#reply_posts" class="nav-link" data-toggle="tab">ひとこと</a>
+    <li class="nav-item tab2_label">
+      <a href="#reply_posts" class="nav-link tab_a" data-toggle="tab">ひとこと</a>
     </li>
-    <li class="nav-item">
-      <a href="#feedback_posts" class="nav-link" data-toggle="tab">フィードバック</a>
+    <li class="nav-item tab3_label">
+      <a href="#feedback_posts" class="nav-link tab_a" data-toggle="tab">フィードバック</a>
     </li>
   </ul>

--- a/app/views/shared/_tabpage.html.erb
+++ b/app/views/shared/_tabpage.html.erb
@@ -11,7 +11,7 @@
         <div id="subject_posts" class="tab-pane active">
 
           <% if @user.subject_posts.any? %>
-            <h3><%= @user.name %>のお題 (<%= @user.subject_posts.count %>)</h3>
+            <h3 class = "title_letter"><%= @user.name %>のお題 (<%= @user.subject_posts.count %>)</h3>
           <% end %>
 
           <%= render "shared/subject_feed", subject_posts: @user.subject_posts %>
@@ -22,7 +22,7 @@
     <%#一言の投稿のタブの中身%>
       <div id="reply_posts" class="tab-pane">
           <% if @user.reply_posts.any? %>
-            <h3><%= @user.name %>のひとこと (<%= @user.reply_posts.count %>)</h3>
+            <h3 class = "title_letter"><%= @user.name %>のひとこと (<%= @user.reply_posts.count %>)</h3>
           <% end %>
 
           <%= render "shared/reply_feed", reply_posts: @user.reply_posts %>
@@ -33,7 +33,7 @@
     <%#フィードバックタブの中身%>
       <div id="feedback_posts" class="tab-pane">
       <% if @user.feedback_posts.any? %>
-        <h3><%= @user.name %>のフィードバック (<%= @user.feedback_posts.count %>)</h3>
+        <h3 class = "title_letter"><%= @user.name %>のフィードバック (<%= @user.feedback_posts.count %>)</h3>
       <% end %>
 
           <%= render "shared/feedback_feed", feedback_posts: @user.feedback_posts %>

--- a/app/views/shared/_tabpage.html.erb
+++ b/app/views/shared/_tabpage.html.erb
@@ -5,45 +5,37 @@
 
   <!-- 内容部分 -->
   <div class="tab-content">
-    <div id="subject_posts" class="tab-pane active">
-      <%#お題投稿のタブの中身%>
-            <% if @user.subject_posts.any? %>
-              <h3>お題 (<%= @user.subject_posts.count %>)</h3>
-              <ol class="subject_posts">
-                <%= render @subject_posts %>
-              </ol>
-                <%= paginate @subject_posts %>
-            <% else %>
-              <p>まだ「お題」は投稿されていません</p>
-            <% end %>
-    </div>
 
-    <div id="reply_posts" class="tab-pane">
-      <%#一言の投稿のタブの中身%>
-            <div class="col-md-8">
-              <% if @user.reply_posts.any? %>
-                <h3>ひとこと (<%= @user.reply_posts.count %>)</h3>
-                <ol class="reply_posts">
-                  <%= render @reply_posts %>
-                </ol>
-                <%= paginate @reply_posts %>
-              <%else%>
-                <p>まだ「ひとこと」は投稿されていません</p>
-              <% end %>
-            </div>
-    </div>
 
-    <div id="feedback_posts" class="tab-pane">
-      <%#フィードバックタブの中身%>
+    <%#お題投稿のタブの中身%>
+        <div id="subject_posts" class="tab-pane active">
+
+          <% if @user.subject_posts.any? %>
+            <h3><%= @user.name %>のお題 (<%= @user.subject_posts.count %>)</h3>
+          <% end %>
+
+          <%= render "shared/subject_feed", subject_posts: @user.subject_posts %>
+
+        </div>
+
+
+    <%#一言の投稿のタブの中身%>
+      <div id="reply_posts" class="tab-pane">
+          <% if @user.reply_posts.any? %>
+            <h3><%= @user.name %>のひとこと (<%= @user.reply_posts.count %>)</h3>
+          <% end %>
+
+          <%= render "shared/reply_feed", reply_posts: @user.reply_posts %>
+
+      </div>
+
+
+    <%#フィードバックタブの中身%>
+      <div id="feedback_posts" class="tab-pane">
       <% if @user.feedback_posts.any? %>
-        <h3>フィードバック (<%= @user.feedback_posts.count %>)</h3>
-        <ol class="reply_posts">
-          <%= render @feedback_posts %>
-        </ol>
-        <%= paginate @feedback_posts %>
-      <%else%>
-        <p>まだ「フィードバック」は投稿されていません</p>
+        <h3><%= @user.name %>のフィードバック (<%= @user.feedback_posts.count %>)</h3>
       <% end %>
-    </div>
+
+          <%= render "shared/feedback_feed", feedback_posts: @user.feedback_posts %>
 
   </div>

--- a/app/views/shared/_tabpage.html.erb
+++ b/app/views/shared/_tabpage.html.erb
@@ -4,38 +4,4 @@
 <%= render 'shared/tab_switch'%>
 
   <!-- 内容部分 -->
-  <div class="tab-content">
-
-
-    <%#お題投稿のタブの中身%>
-        <div id="subject_posts" class="tab-pane active">
-
-          <% if @user.subject_posts.any? %>
-            <h3 class = "title_letter"><%= @user.name %>のお題 (<%= @user.subject_posts.count %>)</h3>
-          <% end %>
-
-          <%= render "shared/subject_feed", subject_posts: @user.subject_posts %>
-
-        </div>
-
-
-    <%#一言の投稿のタブの中身%>
-      <div id="reply_posts" class="tab-pane">
-          <% if @user.reply_posts.any? %>
-            <h3 class = "title_letter"><%= @user.name %>のひとこと (<%= @user.reply_posts.count %>)</h3>
-          <% end %>
-
-          <%= render "shared/reply_feed", reply_posts: @user.reply_posts %>
-
-      </div>
-
-
-    <%#フィードバックタブの中身%>
-      <div id="feedback_posts" class="tab-pane">
-      <% if @user.feedback_posts.any? %>
-        <h3 class = "title_letter"><%= @user.name %>のフィードバック (<%= @user.feedback_posts.count %>)</h3>
-      <% end %>
-
-          <%= render "shared/feedback_feed", feedback_posts: @user.feedback_posts %>
-
-  </div>
+<%= render 'shared/tab_contents'%>

--- a/app/views/shared/_tabpage.html.erb
+++ b/app/views/shared/_tabpage.html.erb
@@ -1,7 +1,11 @@
-<%#user#show用のタブページ%>
+<%#homeとuserページ共通テンプレート%>
 
-<!-- 上部のタブの部分 -->
-<%= render 'shared/tab_switch'%>
+<div class = tab_field>
 
-  <!-- 内容部分 -->
-<%= render 'shared/tab_contents'%>
+  <!-- 上部のタブの部分 -->
+  <%= render 'shared/tab_switch'%>
+
+    <!-- 内容部分 -->
+  <%= render 'shared/tab_contents'%>
+
+</div>

--- a/app/views/shared/_tabpage_feed.html.erb
+++ b/app/views/shared/_tabpage_feed.html.erb
@@ -10,9 +10,8 @@
       <div class = "homepage-title under_tub_title">
         <h3 class = "title_letter">投稿したお題一覧</h3>
       </div>
-
           <%= render 'shared/subject_feed' %>
-        
+
     </div>
 
     <div id="reply_posts" class="tab-pane">

--- a/app/views/shared/_tabpage_feed.html.erb
+++ b/app/views/shared/_tabpage_feed.html.erb
@@ -4,30 +4,5 @@
 <%= render 'shared/tab_switch'%>
 
   <!-- 内容部分 -->
-  <div class="tab-content panel_area">
-    <div id="subject_posts" class="tab-pane active tab_panel">
-      <%#お題投稿のタブのfeed%>
-      <div class = "homepage-title under_tub_title">
-        <h3 class = "title_letter">投稿したお題一覧</h3>
-      </div>
-          <%= render 'shared/subject_feed' %>
 
-    </div>
-
-    <div id="reply_posts" class="tab-pane tab_panel">
-      <%#一言の投稿のタブの中身%>
-      <div class = "homepage-title under_tub_title">
-        <h3 class = "title_letter">投稿したひとこと一覧</h3>
-      </div>
-        <%= render 'shared/reply_feed' %>
-    </div>
-
-    <div id="feedback_posts" class="tab-pane tab_panel">
-      <%#フィードバックタブの中身%>
-      <div class = "homepage-title under_tub_title">
-        <h3 class = "title_letter">投稿したフィードバック一覧</h3>
-      </div>
-      <%= render 'shared/feedback_feed' %>
-    </div>
-
-  </div>
+<%= render 'shared/tab_contents'%>

--- a/app/views/shared/_tabpage_feed.html.erb
+++ b/app/views/shared/_tabpage_feed.html.erb
@@ -10,8 +10,9 @@
       <div class = "homepage-title under_tub_title">
         <h3 class = "title_letter">投稿したお題一覧</h3>
       </div>
-          <%= render 'shared/subject_feed' %>
 
+          <%= render 'shared/subject_feed' %>
+        
     </div>
 
     <div id="reply_posts" class="tab-pane">

--- a/app/views/shared/_tabpage_feed.html.erb
+++ b/app/views/shared/_tabpage_feed.html.erb
@@ -1,8 +1,0 @@
-<%#home用のタブページ%>
-
-  <!-- 上部のタブの部分 -->
-<%= render 'shared/tab_switch'%>
-
-  <!-- 内容部分 -->
-
-<%= render 'shared/tab_contents'%>

--- a/app/views/shared/_tabpage_feed.html.erb
+++ b/app/views/shared/_tabpage_feed.html.erb
@@ -4,8 +4,8 @@
 <%= render 'shared/tab_switch'%>
 
   <!-- 内容部分 -->
-  <div class="tab-content">
-    <div id="subject_posts" class="tab-pane active">
+  <div class="tab-content panel_area">
+    <div id="subject_posts" class="tab-pane active tab_panel">
       <%#お題投稿のタブのfeed%>
       <div class = "homepage-title under_tub_title">
         <h3 class = "title_letter">投稿したお題一覧</h3>
@@ -14,7 +14,7 @@
 
     </div>
 
-    <div id="reply_posts" class="tab-pane">
+    <div id="reply_posts" class="tab-pane tab_panel">
       <%#一言の投稿のタブの中身%>
       <div class = "homepage-title under_tub_title">
         <h3 class = "title_letter">投稿したひとこと一覧</h3>
@@ -22,7 +22,7 @@
         <%= render 'shared/reply_feed' %>
     </div>
 
-    <div id="feedback_posts" class="tab-pane">
+    <div id="feedback_posts" class="tab-pane tab_panel">
       <%#フィードバックタブの中身%>
       <div class = "homepage-title under_tub_title">
         <h3 class = "title_letter">投稿したフィードバック一覧</h3>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -1,4 +1,4 @@
 <%= link_to gravatar_for(current_user, size: 50), current_user %>
 <h1><%= current_user.name %></h1>
-<span><%= link_to "プロフィールを見る", current_user %></span>
+<span><%= button_to "プロフィールを見る", current_user, {method: :get, class: "general_button"} %></span>
 <span>お題投稿数:<%= current_user.subject_posts.count %></span>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -1,4 +1,8 @@
 <%= link_to gravatar_for(current_user, size: 50), current_user %>
 <h1><%= current_user.name %></h1>
-<span><%= button_to "プロフィールを見る", current_user, {method: :get, class: "general_button"} %></span>
-<span>お題投稿数:<%= current_user.subject_posts.count %></span>
+<p>
+<span><%= button_to "プロフィールを見る！", current_user, {method: :get, class: "ungeneral_button",form: {style: 'display:inline;'}} %></span>
+</p>
+<span clas = "post_count">お題投稿数:<%= current_user.subject_posts.count %></span>
+<span clas = "post_count">ひとこと投稿数:<%= current_user.reply_posts.count %></span>
+<span clas = "post_count">フィードバック投稿数:<%= current_user.feedback_posts.count %></span>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -3,36 +3,39 @@
   <%= render "shared/breadcrumbs" %>
 
     <div class="row">
-      <aside class="col-md-4">
+      <aside class="col-md-6">
         <section class="user_info">
           <%= render 'shared/user_info' %>
         </section>
-        <section class="subject_posts_form">
+      </aside>
 
+      <aside class="col-md-6">
+        <section class="subject_posts_form">
           <%= render 'shared/subject_posts_form' %>
         </section>
       </aside>
-      <div class="col-md-8">
-
-        <%= render 'shared/tabpage_feed' %>
-
-      </div>
     </div>
-<% else %>
 
-  <div class="col-md-12 landing_container">
-    <div class = "landing">
-      <h1 class = main_title>LinGoChanにようこそ！</h1>
-      <div class = mongon>
-        <p>誰かが画像を投稿し</p>
-        <p>誰かがコメントを残し</p>
-        <p>誰かがフィードバックしてくれる</p>
+    <div class="item_field">
+        <%= render 'shared/tabpage_feed' %>
+    </div>
+
+
+<% else %>
+  <div class="row">
+    <div class="col-md-12 landing_container">
+      <div class = "landing">
+        <h1 class = main_title>LinGoChanにようこそ！</h1>
+        <div class = mongon>
+          <p>誰かが画像を投稿し</p>
+          <p>誰かがコメントを残し</p>
+          <p>誰かがフィードバックしてくれる</p>
+        </div>
+        <p class= "kimezerifu">全く新しい日本語学習アプリ</p>
+        <%= link_to "いますぐ始める！", signup_path, class: "btn btn-lg btn-primary landing_button" %>
+        <%= link_to "LinGoChanって何?", about_path, class: "btn btn-lg btn-primary landing_button" %>
+        <%= button_to "ゲストユーザーとしてログイン", guest_path, method: :post, class: 'btn btn-success landing_button' %>
       </div>
-      <p class= "kimezerifu">全く新しい日本語学習アプリ</p>
-      <%= link_to "いますぐ始める！", signup_path, class: "btn btn-lg btn-primary landing_button" %>
-      <%= link_to "LinGoChanって何?", about_path, class: "btn btn-lg btn-primary landing_button" %>
-      <%= button_to "ゲストユーザーとしてログイン", guest_path, method: :post, class: 'btn btn-success landing_button' %>
     </div>
   </div>
-
 <% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -22,20 +22,18 @@
 
 
 <% else %>
-  <div class="row">
-    <div class="col-md-12 landing_container">
-      <div class = "landing">
-        <h1 class = main_title>LinGoChanにようこそ！</h1>
-        <div class = mongon>
-          <p>誰かが画像を投稿し</p>
-          <p>誰かがコメントを残し</p>
-          <p>誰かがフィードバックしてくれる</p>
-        </div>
-        <p class= "kimezerifu">全く新しい日本語学習アプリ</p>
-        <%= link_to "いますぐ始める！", signup_path, class: "btn btn-lg btn-primary landing_button" %>
-        <%= link_to "LinGoChanって何?", about_path, class: "btn btn-lg btn-primary landing_button" %>
-        <%= button_to "ゲストユーザーとしてログイン", guest_path, method: :post, class: 'btn btn-success landing_button' %>
+  <div class="row landing_container">
+    <div class = "col-md-12 landing">
+      <h1 class = main_title>LinGoChan</h1>
+      <div class = mongon>
+        <p>誰かが画像を投稿し</p>
+        <p>誰かがコメントを残し</p>
+        <p>誰かがフィードバックしてくれる</p>
       </div>
+      <p class= "kimezerifu">全く新しい日本語学習アプリ</p>
+      <%= link_to "いますぐ始める！", signup_path, class: "btn btn-lg btn-primary landing_button" %>
+      <%= link_to "LinGoChanって何?", about_path, class: "btn btn-lg btn-primary landing_button" %>
+      <%= button_to "ゲストユーザーとしてログイン", guest_path, method: :post, class: 'btn btn-success landing_button' %>
     </div>
   </div>
 <% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,14 +2,14 @@
   <% breadcrumb :root%>
   <%= render "shared/breadcrumbs" %>
 
-    <div class="row">
-      <aside class="col-md-6">
-        <section class="user_info">
+    <div class="row common_row upper_info_row">
+      <aside class="col-md-6 common_col upper_info">
+        <section class="user_info upper_user_info">
           <%= render 'shared/user_info' %>
         </section>
       </aside>
 
-      <aside class="col-md-6">
+      <aside class="col-md-6 common_col upper_post">
         <section class="subject_posts_form">
           <%= render 'shared/subject_posts_form' %>
         </section>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -17,7 +17,7 @@
     </div>
 
     <div class="item_field">
-        <%= render 'shared/tabpage_feed' %>
+        <%= render 'shared/tabpage' %>
     </div>
 
 

--- a/app/views/subject_posts/_subject_post.html.erb
+++ b/app/views/subject_posts/_subject_post.html.erb
@@ -1,7 +1,7 @@
 <div class = "subject_post_container">
   <div class = "subject_post">
 
-    <li id="subject_post-<%= subject_post.id %>">
+    <div id="subject_post-<%= subject_post.id %>">
       <%= link_to gravatar_for(subject_post.user, size: 50), subject_post.user %>
       <span class="user"><%= link_to subject_post.user.name, subject_post.user %></span>
 
@@ -16,7 +16,7 @@
       </span>
 
       <%= render "/shared/subject_post_tag_list", subject_post: subject_post  %>
-    </li>
+    </div>
 
   </div>
 </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,3 +1,4 @@
+
     <li>
       <%= gravatar_for user, size: 50 %>
       <%= link_to user.name, user %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,5 +1,5 @@
 
-    <li>
+    <li class = col-mid-2 user>
       <%= gravatar_for user, size: 50 %>
       <%= link_to user.name, user %>
       <% if current_user.admin? && !current_user?(user) %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -24,7 +24,8 @@
     <% end %>
 <div class="gravatar_edit">
       <%= gravatar_for @user %>
-      <a href="http://gravatar.com/emails" target="_blank">変更する！</a>
+      <a href="http://gravatar.com/emails" target="_blank"></a>
+      <span><%= button_to "変更する！", "http://gravatar.com/emails", {method: :get, class: "ungeneral_button", form: {style: 'display:inline;'}, target: "_blank" } %></span>
     </div>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,7 +7,7 @@
 
 <%= paginate @users %>
 
-<ul class="users">
+<ul class="users row">
 
   <%= render @users %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,16 +3,29 @@
 <% breadcrumb :show, @user%>
 <%= render "shared/breadcrumbs" %>
 
-  <section class="row user_info">
-    <aside class="col-md-6">
+  <section class="row user_info upper_info_row">
+    <aside class="col-md-6 upper_user_info">
         <%= gravatar_for @user %>
           <h1> <%= @user.name %> </h1>
+
+        <% if current_user?(@user) %>
+        <p>
+        <span><%= button_to "自己紹介を書いてみる", edit_user_path(current_user), {method: :get, class: "ungeneral_button",form: {style: 'display:inline;'}} %></span>
+        </p>
+        <% end %>
+
+        <span clas = "post_count">お題投稿数:<%= @user.subject_posts.count %></span>
+        <span clas = "post_count">ひとこと投稿数:<%= @user.reply_posts.count %></span>
+        <span clas = "post_count">フィードバック投稿数:<%= @user.feedback_posts.count %></span>
+
    </aside>
 
       <%#自己紹介%>
     <aside class="col-md-6">
       <div class = "self_introduction">
+        <p class = "self_introduction_text">
         <%= @user.self_introduction %>
+        </p>
       </div>
     </aside>
   </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
 
         <% if current_user?(@user) %>
         <p>
-        <span><%= button_to "自己紹介を書いてみる", edit_user_path(current_user), {method: :get, class: "ungeneral_button",form: {style: 'display:inline;'}} %></span>
+        <span><%= button_to "自己紹介を書いてみる！", edit_user_path(current_user), {method: :get, class: "ungeneral_button",form: {style: 'display:inline;'}} %></span>
         </p>
         <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,22 +3,20 @@
 <% breadcrumb :show, @user%>
 <%= render "shared/breadcrumbs" %>
 
-<div class="row">
-  <aside class="col-md-4">
-    <section class="user_info">
-      <h1>
+  <section class="row user_info">
+    <aside class="col-md-6">
         <%= gravatar_for @user %>
-        <%= @user.name %>
-      </h1>
+          <h1> <%= @user.name %> </h1>
+   </aside>
 
       <%#自己紹介%>
+    <aside class="col-md-6">
       <div class = "self_introduction">
         <%= @user.self_introduction %>
       </div>
+    </aside>
+  </section>
 
-    </section>
-  </aside>
-  <div class="col-md-8">
+  <div class="item_field">
     <%= render "shared/tabpage"%>
   </div>
-</div>


### PR DESCRIPTION
本コミットでの変更点は以下の通りです

１、static_pages#homeの　トップ画像と名前＋画像投稿欄　及び　users#showの　トップ画像と名前＋プロフィール欄　を右側からサイト上部に移動させました。

２，各投稿(subject, reply, feedback_posts)を横2行で整列させました。
　　その際、user#showにおける部分テンプレートshared/tabpage内にて、static_pages#homeに使われている部分テンプレー　ト、subject, reply, feedback_feedが再利用できそうだったので、リファクタリングも行っています。