### PR TITLE
designed custom_button and admin area

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,9 @@ private
       user.activate
       log_in(user)
     end
+
+    # 管理者かどうか確認
+        def admin_user
+          redirect_to(root_url) unless current_user.admin?
+        end
 end

--- a/app/controllers/feedback_posts_controller.rb
+++ b/app/controllers/feedback_posts_controller.rb
@@ -1,7 +1,7 @@
 class FeedbackPostsController < ApplicationController
-
   before_action :logged_in_user, only: [:create, :destroy, :edit]
-  before_action :correct_user, only: [:destroy, :edit, :update]
+  before_action :correct_user, only: [:edit, :update]
+  before_action :correct_user_or_admin_user, only: [:destroy]
 
   def create
     @feedback_post = current_user.feedback_posts.build(feedback_post_params)
@@ -18,7 +18,7 @@ class FeedbackPostsController < ApplicationController
   def destroy
     @feedback_post.destroy
     flash[:success] = "投稿を消去しました"
-    redirect_to request.referrer || root_url
+    redirect_to root_url
   end
 
   def edit
@@ -52,5 +52,14 @@ private
   def correct_user
       @feedback_post = current_user.feedback_posts.find_by(id: params[:id])
       redirect_to root_url if @feedback_post.nil?
+  end
+
+  def correct_user_or_admin_user
+    @feedback_post = current_user.feedback_posts.find_by(id: params[:id])
+    admin_boolean = current_user.admin?
+    if admin_boolean == true
+      @feedback_post = FeedbackPost.find_by(id: params[:id])
     end
+    redirect_to root_url if @feedback_post.nil? && admin_boolean == false
+  end
 end

--- a/app/controllers/reply_posts_controller.rb
+++ b/app/controllers/reply_posts_controller.rb
@@ -26,6 +26,12 @@ class ReplyPostsController < ApplicationController
     @feedback_post = @reply_post.feedback_posts.build
   end
 
+  def destroy
+    @reply_post.destroy
+    flash[:success] = "投稿を消去しました"
+    redirect_to request.referrer || root_url
+  end
+
   private
     def reply_post_params
     params.require(:reply_post).permit(:content, :subject_post_id)

--- a/app/controllers/reply_posts_controller.rb
+++ b/app/controllers/reply_posts_controller.rb
@@ -1,6 +1,7 @@
 class ReplyPostsController < ApplicationController
   before_action :logged_in_user, only: [:create]
   before_action :admin_user,     only: [:destroy]
+
   def create
     @reply_post = current_user.reply_posts.build(reply_post_params)
     if @reply_post.save

--- a/app/controllers/reply_posts_controller.rb
+++ b/app/controllers/reply_posts_controller.rb
@@ -1,7 +1,6 @@
 class ReplyPostsController < ApplicationController
   before_action :logged_in_user, only: [:create]
-#reply_postは画像削除を実装しない。
-
+  before_action :admin_user,     only: [:destroy]
   def create
     @reply_post = current_user.reply_posts.build(reply_post_params)
     if @reply_post.save
@@ -27,9 +26,10 @@ class ReplyPostsController < ApplicationController
   end
 
   def destroy
+    @reply_post = ReplyPost.find(params[:id])
     @reply_post.destroy
     flash[:success] = "投稿を消去しました"
-    redirect_to request.referrer || root_url
+    redirect_to root_url
   end
 
   private

--- a/app/controllers/subject_posts_controller.rb
+++ b/app/controllers/subject_posts_controller.rb
@@ -1,5 +1,6 @@
 class SubjectPostsController < ApplicationController
   before_action :logged_in_user, only: [:create, :show]
+  before_action :admin_user,     only: [:destroy]
 #subject_postは画像削除を実装しない。
 #一覧(index)は非ログインユーザでも見れる。
 
@@ -30,9 +31,10 @@ class SubjectPostsController < ApplicationController
   end
 
   def destroy
+    @subject_post = SubjectPost.find(params[:id])
     @subject_post.destroy
     flash[:success] = "投稿を消去しました"
-    redirect_to request.referrer || root_url
+    redirect_to root_url
   end
 
   private

--- a/app/controllers/subject_posts_controller.rb
+++ b/app/controllers/subject_posts_controller.rb
@@ -29,6 +29,12 @@ class SubjectPostsController < ApplicationController
     @subject_post_tags = @subject_post.tags           #クリックした投稿に紐付けられているタグを取得。
   end
 
+  def destroy
+    @subject_post.destroy
+    flash[:success] = "投稿を消去しました"
+    redirect_to request.referrer || root_url
+  end
+
   private
     def subject_post_params
      params.require(:subject_post).permit(:img)

--- a/app/controllers/subject_posts_controller.rb
+++ b/app/controllers/subject_posts_controller.rb
@@ -1,8 +1,7 @@
 class SubjectPostsController < ApplicationController
   before_action :logged_in_user, only: [:create, :show]
   before_action :admin_user,     only: [:destroy]
-#subject_postは画像削除を実装しない。
-#一覧(index)は非ログインユーザでも見れる。
+#一覧(index)は非ログインユーザでも見れるようにしたい(後々)
 
   def create
     @subject_post = current_user.subject_posts.build(subject_post_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 before_action :logged_in_user, only: [:index, :edit, :update, :destroy, :show]
 before_action :correct_user,   only: [:edit, :update]
-before_action :admin_user,     only: :destroy
+before_action :admin_user,     only: [:destroy]
 
   def new
     @user = User.new
@@ -61,10 +61,5 @@ before_action :admin_user,     only: :destroy
     def correct_user
       @user = User.find(params[:id])
       redirect_to(root_url) unless current_user?(@user)
-    end
-
-# 管理者かどうか確認
-    def admin_user
-      redirect_to(root_url) unless current_user.admin?
     end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -177,6 +177,28 @@
     color: #FFF;
 }
 
+/*bootstrap感を消したい！(ボタン)*/
+.custom_button {
+  display: inline-block;
+  max-width: 180px;
+  text-align: left;
+  border: 2px solid #2e8b57;
+  font-size: 16px;
+  color: #2e8b57;
+  text-decoration: none;
+  font-weight: bold;
+  padding: 8px 16px;
+  border-radius: 4px;
+  transition: .4s;
+  margin: 20px ;
+}
+
+.custom_button:hover {
+  background-color: #2e8b57;
+  border-color: #cbe585;
+  color: #FFF;
+}
+
 /*ボタンここまで*/
 
 

--- a/app/javascript/stylesheets/posts.scss
+++ b/app/javascript/stylesheets/posts.scss
@@ -100,3 +100,8 @@
   background-color:rgb(208,226,190); /*https://www.i-iro.com/dic/usumidori*/
 
 }
+
+/*adminのみが削除出来るエリア*/
+.admin_area{
+  background-color: #f0908d; /*薄紅*/
+}

--- a/app/javascript/stylesheets/posts.scss
+++ b/app/javascript/stylesheets/posts.scss
@@ -58,6 +58,11 @@
     border-left : solid 1px #dcdcdc; /*gainsboro*/
 }
 
+/*タイムスタンプ*/
+.timestamp{
+  margin-left: 10px;
+}
+
 #timestamp{
   background-color:rgb(208,226,190); /*https://www.i-iro.com/dic/usumidori*/
   color: #ffffff;
@@ -93,4 +98,5 @@
 .post_image{
   padding: 3px;
   background-color:rgb(208,226,190); /*https://www.i-iro.com/dic/usumidori*/
+
 }

--- a/app/views/feedback_posts/_feedback_post.html.erb
+++ b/app/views/feedback_posts/_feedback_post.html.erb
@@ -23,11 +23,15 @@
           <%= render 'shared/timestamp', post: feedback_post %>
         </div>
 
+      <%# もし今のページがsubject_postのshowのページで、現在のユーザーが管理者のとき消せる %>
+        <%= render 'shared/admin_delete_area', {post: feedback_post, posts: "feedback_posts"} %>
+
+
   <%#もし、フィードバックのshow(詳細ページ)でcurrent_userだったら消去と編集、それ以外だったら「詳しく見る」を表示%>
         <div class = detail_or_edit_delete>
           <% if current_page?("/feedback_posts/#{feedback_post.id}") %>
             <span class = "delete">
-              <% if current_user?(@feedback_post.user) %>
+              <% if current_user?(@feedback_post.user) && !current_user.admin? %>
                 <%= button_to "消去", @feedback_post, {method: :delete, class: "general_button", data: { confirm: "本当に消去してもいいですか？" }} %>
               <% end %>
             </span>

--- a/app/views/feedback_posts/edit.html.erb
+++ b/app/views/feedback_posts/edit.html.erb
@@ -50,7 +50,7 @@
       <div class="field" "フィードバック">
         <%= f.text_area :content, placeholder: "フィードバックを書いてください" %>
       </div>
-      <%= f.submit "投稿する！", class: "btn btn-primary" %>
+      <%= f.submit "投稿する！", class: "btn custom_button" %>
     <% end %>
   </div>
 

--- a/app/views/reply_posts/_reply_post.html.erb
+++ b/app/views/reply_posts/_reply_post.html.erb
@@ -33,7 +33,16 @@
             </div>
           <% end %>
 
-
+  <%# もし今のページがreply_postのshowのページで、現在のユーザーが管理者のとき消せる %>
+          <div class = "admin_area">
+            <% if current_page?("/reply_posts/#{reply_post.id}") %>
+              <span class = "delete">
+                <% if current_user.admin? %>
+                  <%= button_to "消去", @reply_post, {method: :delete, class: "general_button", data: { confirm: "本当に消去してもいいですか？" }} %>
+                <% end %>
+              </span>
+            <% end %>
+          </div>
 
       </div>
     </div>

--- a/app/views/reply_posts/_reply_post.html.erb
+++ b/app/views/reply_posts/_reply_post.html.erb
@@ -34,15 +34,7 @@
           <% end %>
 
   <%# もし今のページがreply_postのshowのページで、現在のユーザーが管理者のとき消せる %>
-          <div class = "admin_area">
-            <% if current_page?("/reply_posts/#{reply_post.id}") %>
-              <span class = "delete">
-                <% if current_user.admin? %>
-                  <%= button_to "消去", @reply_post, {method: :delete, class: "general_button", data: { confirm: "本当に消去してもいいですか？" }} %>
-                <% end %>
-              </span>
-            <% end %>
-          </div>
+          <%= render 'shared/admin_delete_area', {post: reply_post, posts: "reply_posts"} %>
 
       </div>
     </div>

--- a/app/views/shared/_admin_delete_area.html.erb
+++ b/app/views/shared/_admin_delete_area.html.erb
@@ -1,0 +1,36 @@
+<div class = "admin_area">
+
+  <% if posts == "subject_posts" %>
+    <% if current_page?("/subject_posts/#{post.id}") %>
+    <span class = "delete">
+      <% if current_user.admin? %>
+        <%= button_to "消去", post, {method: :delete, class: "general_button",
+                                data: { confirm: "本当に消去してもいいですか？" }, } %>
+      <% end %>
+    </span>
+  <% end %>
+
+  <% elsif posts == "reply_posts" %>
+    <% if current_page?("/reply_posts/#{post.id}") %>
+    <span class = "delete">
+      <% if current_user.admin? %>
+        <%= button_to "消去", post, {method: :delete, class: "general_button",
+                                data: { confirm: "本当に消去してもいいですか？" }, } %>
+      <% end %>
+    </span>
+  <% end %>
+
+  <% elsif posts == "feedback_posts" %>
+    <% if current_page?("/feedback_posts/#{post.id}") %>
+    <span class = "delete">
+      <% if current_user.admin? %>
+        <%= button_to "消去", post, {method: :delete, class: "general_button",
+                                data: { confirm: "本当に消去してもいいですか？" }, } %>
+      <% end %>
+    </span>
+   <% end %>
+
+<% end %>
+
+
+</div>

--- a/app/views/shared/_feedback_posts_form.html.erb
+++ b/app/views/shared/_feedback_posts_form.html.erb
@@ -5,5 +5,5 @@
     <%= f.text_area :content, placeholder: "フィードバックを書いてください" %>
   </div>
 <%= f.hidden_field :reply_post_id, value: @reply_post.id %>
-  <%= f.submit "投稿する！", class: "btn btn-primary" %>
+  <%= f.submit "投稿する！", class: "btn custom_button" %>
 <% end %>

--- a/app/views/shared/_reply_posts_form.html.erb
+++ b/app/views/shared/_reply_posts_form.html.erb
@@ -5,5 +5,5 @@
     <%= f.text_area :content, placeholder: "お題に対して一言..." %>
   </div>
   <%= f.hidden_field :subject_post_id, value: @subject_post.id %>
-  <%= f.submit "投稿する！", class: "btn btn-primary"%>
+  <%= f.submit "投稿する！", class: "btn custom_button"%>
 <% end %>

--- a/app/views/shared/_subject_posts_form.html.erb
+++ b/app/views/shared/_subject_posts_form.html.erb
@@ -20,7 +20,7 @@
         <%= f.label :tag_name, "タグ"%>
         <%= f.text_field :tag_name %>
     </div>
- <%= f.submit "投稿する！", class: "btn btn-primary" %>
+ <%= f.submit "投稿する！", class: "btn custom_button" %>
 </div>
 <% end %>
 

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -32,9 +32,9 @@
         <p>誰かがフィードバックしてくれる</p>
       </div>
       <p class= "kimezerifu">全く新しい日本語学習アプリ</p>
-      <%= link_to "いますぐ始める！", signup_path, class: "btn btn-lg btn-primary landing_button" %>
-      <%= link_to "LinGoChanって何?", about_path, class: "btn btn-lg btn-primary landing_button" %>
-      <%= button_to "ゲストユーザーとしてログイン", guest_path, method: :post, class: 'btn btn-success landing_button' %>
+      <%= link_to "いますぐ始める！", signup_path, class: "btn btn-lg custom_button" %>
+      <%= link_to "LinGoChanって何?", about_path, class: "btn btn-lg custom_button" %>
+      <%= button_to "ゲストユーザーとしてログイン", guest_path, method: :post, class: 'btn btn-success guest_button' %>
     </div>
   </div>
 <% end %>

--- a/app/views/subject_posts/_subject_post.html.erb
+++ b/app/views/subject_posts/_subject_post.html.erb
@@ -22,5 +22,16 @@
       <%= render "/shared/subject_post_tag_list", subject_post: subject_post  %>
     </div>
 
+<%# もし今のページがsubject_postのshowのページで、現在のユーザーが管理者のとき消せる %>
+    <div class = "admin_area">
+      <% if current_page?("/subject_posts/#{subject_post.id}") %>
+        <span class = "delete">
+          <% if current_user.admin? %>
+            <%= button_to "消去", @subject_post, {method: :delete, class: "general_button", data: { confirm: "本当に消去してもいいですか？" }} %>
+          <% end %>
+        </span>
+      <% end %>
+    </div>
+
   </div>
 </div>

--- a/app/views/subject_posts/_subject_post.html.erb
+++ b/app/views/subject_posts/_subject_post.html.erb
@@ -23,15 +23,8 @@
     </div>
 
 <%# もし今のページがsubject_postのshowのページで、現在のユーザーが管理者のとき消せる %>
-    <div class = "admin_area">
-      <% if current_page?("/subject_posts/#{subject_post.id}") %>
-        <span class = "delete">
-          <% if current_user.admin? %>
-            <%= button_to "消去", @subject_post, {method: :delete, class: "general_button", data: { confirm: "本当に消去してもいいですか？" }} %>
-          <% end %>
-        </span>
-      <% end %>
-    </div>
+
+    <%= render 'shared/admin_delete_area', {post: subject_post, posts: "subject_posts"} %>
 
   </div>
 </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -3,7 +3,7 @@
       <%= gravatar_for user, size: 50 %>
       <%= link_to user.name, user %>
       <% if current_user.admin? && !current_user?(user) %>
-        <%= button_to '削除', "/tags/#{list.id}", {method: :delete, data: { confirm: "You sure?" },
+        <%= button_to '削除', user, {method: :delete, data: { confirm: "You sure?" },
                                  class: "ungeneral_button", form: {style: 'display:inline;'}} %>
       <% end %>
     </li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -21,7 +21,7 @@
               <%= f.text_area :self_introduction, class: 'form-control', id: 'user_introduction', placeholder: "国籍, 日本語のレベル, 趣味, 特技など..."%>
 
         <div class = "edit_save">
-          <%= f.submit "保存する！", class: "btn btn-primary" %>
+          <%= f.submit "保存する！", class: "btn custom_button" %>
         </div>
     <% end %>
       <div class="gravatar_edit">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
 
-  resources :subject_posts,       only: [:create, :show, :index]
-  resources :reply_posts,         only: [:create, :show, :index]
+  resources :subject_posts,       only: [:create, :show, :index, :destroy]
+  resources :reply_posts,         only: [:create, :show, :index, :destroy]
   resources :feedback_posts,      only: [:create, :show, :destroy, :edit, :index, :update]
 
   resources :tags,                only: [:destroy, :create] do


### PR DESCRIPTION
bootstrapで実装していたボタンをデザインし直しました。
また、subject_post, reply_postに関してはアプリ上で消去する術がなかったので、adminのみ消去できるようにしました。
deleteのためのボタンをshared/_admin_delete_areaに移しています。

shared/_admin_delete_fieldですが、

current_page?("/subject_posts/#{post.id}")
current_page?("/reply_posts/#{post.id}")
current_page?("/feedback_posts/#{post.id}")

のxxx_postsへの
への変数の渡し方がどうしても分からなかったので煩雑なコードになっています。

また、switch文で書いても、renderingがうまくいかないので、今回は採用していません。

また、feedbackのbefore_actionのcorrect_userから:deleteを消し、新たにcorrect_user_or_admin_userを作成し、正しいユーザまたは管理者のみがdeleteを使用できるように変更しています。